### PR TITLE
Add skin for sequence diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ architecture modelling.
 
 ## Contents
 - [C4 Modelling skin](src/C4)
+- [Sequence Diagrams skin](src/sequence)
 
 ## License
 The content in this repository is provided under the MIT License.

--- a/src/sequence/README.md
+++ b/src/sequence/README.md
@@ -1,0 +1,22 @@
+# Sequence Diagram skin
+
+This skin enhances the visuals for PlantUML sequence diagrams.
+
+## Usage
+You will need to import the `sequence.puml` file.
+```
+@startuml
+!includeurl https://raw.githubusercontent.com/TheIconic/PlantUML-skins/master/src/sequence/sequence.puml
+
+'...define your sequence diagram...
+
+@enduml
+```
+
+## Syntax & Examples
+See [samples](samples) folder for examples and syntax.
+
+You will find almost all features used in the [Kitchensink](samples/Kitchensink.puml).
+
+You can also consult [the PlantUML documentation for sequence diagrams](https://plantuml.com/sequence-diagram)
+for syntax documentation and more examples.

--- a/src/sequence/samples/Kitchensink.puml
+++ b/src/sequence/samples/Kitchensink.puml
@@ -1,0 +1,43 @@
+@startuml
+!include ../sequence.puml
+
+autonumber
+actor Actor
+box "Internal Service"
+    participant Application <<application>>
+    participant Service <<service>>
+end box
+boundary Boundary
+control Control
+entity Entity
+database Database
+collections Collections
+
+== initialization ==
+note left of Application
+a note with some text
+over multiple lines
+end note
+
+[-> Actor
+Actor -> Application
+... a delay with text ...
+loop 10 times
+Application -> Service: start doing things during duration
+activate Service
+Service ->> Boundary : hello
+Service -\\ Control : hello
+Service -\ Entity : hello
+Service -/ Database : hello
+ref over Service
+  what is a ref, exactly
+end ref
+Service -// Collections : hello
+Service -> Application : finish
+deactivate Service
+end
+...
+Actor <-- Application
+newpage with text
+[<-- Actor
+@enduml

--- a/src/sequence/sequence.puml
+++ b/src/sequence/sequence.puml
@@ -1,0 +1,141 @@
+hide stereotype
+
+!define SEQUENCE_LINE_COLOR #347cb2
+!define SEQUENCE_FILL_COLOR #347cb2
+
+!define SEQUENCE_ARROW_COLOR #347cb2
+
+!define SEQUENCE_PARTICIPANT_FONT_STYLE Bold
+!define SEQUENCE_PARTICIPANT_FONT_SIZE 14
+
+skinparam {
+  Shadowing false
+  RoundCorner 4
+}
+
+skinparam actor {
+  FontColor SEQUENCE_LINE_COLOR
+  BackgroundColor #FFFFFF
+  BorderColor SEQUENCE_LINE_COLOR
+  FontStyle SEQUENCE_PARTICIPANT_FONT_STYLE
+  FontSize SEQUENCE_PARTICIPANT_FONT_SIZE
+}
+
+skinparam participant {
+  FontColor #FFFFFF
+  BackgroundColor SEQUENCE_FILL_COLOR
+  BorderColor #ffffff
+  FontStyle SEQUENCE_PARTICIPANT_FONT_STYLE
+  FontSize SEQUENCE_PARTICIPANT_FONT_SIZE
+  BorderThickness 1
+}
+
+skinparam boundary {
+  FontColor SEQUENCE_LINE_COLOR
+  BackgroundColor #FFFFFF
+  BorderColor SEQUENCE_LINE_COLOR
+  FontStyle SEQUENCE_PARTICIPANT_FONT_STYLE
+  FontSize SEQUENCE_PARTICIPANT_FONT_SIZE
+}
+
+skinparam control {
+  FontColor SEQUENCE_LINE_COLOR
+  BackgroundColor #FFFFFF
+  BorderColor SEQUENCE_FILL_COLOR
+  FontStyle SEQUENCE_PARTICIPANT_FONT_STYLE
+  FontSize SEQUENCE_PARTICIPANT_FONT_SIZE
+}
+
+skinparam entity {
+  FontColor SEQUENCE_LINE_COLOR
+  BackgroundColor #FFFFFF
+  BorderColor SEQUENCE_LINE_COLOR
+  FontStyle SEQUENCE_PARTICIPANT_FONT_STYLE
+  FontSize SEQUENCE_PARTICIPANT_FONT_SIZE
+}
+
+skinparam database {
+  FontColor SEQUENCE_LINE_COLOR
+  BackgroundColor SEQUENCE_FILL_COLOR
+  BorderColor #FFFFFF
+  FontStyle SEQUENCE_PARTICIPANT_FONT_STYLE
+  FontSize SEQUENCE_PARTICIPANT_FONT_SIZE
+}
+
+skinparam collections {
+  FontColor #FFFFFF
+  BackgroundColor SEQUENCE_FILL_COLOR
+  BorderColor #FFFFFF
+  FontStyle SEQUENCE_PARTICIPANT_FONT_STYLE
+  FontSize SEQUENCE_PARTICIPANT_FONT_SIZE
+}
+
+skinparam note {
+  FontColor #443311
+  BackgroundColor #f9f0d0
+  BorderColor #d0c090
+}
+
+skinparam box {
+  Padding 10
+}
+
+skinparam arrow {
+  Color SEQUENCE_ARROW_COLOR
+  FontColor SEQUENCE_ARROW_COLOR
+}
+
+skinparam sequence {
+  Box {
+    FontColor #a0a0a0
+    BackgroundColor #f0f0f0
+    BorderColor #c0c0c0
+  }
+
+  Delay {
+    FontColor SEQUENCE_LINE_COLOR
+  }
+
+  Divider {
+    FontColor #ffffff
+    BackgroundColor #c0c0c0
+    BorderColor #ffffff
+    BorderThickness 1
+  }
+
+  Group {
+    FontColor #444444
+    HeaderFontColor #444444
+    BodyBackgroundColor #FFFFFF
+    BackgroundColor #F0F0F0
+    BorderColor #c0c0c0
+    BorderThickness 1
+  }
+
+  LifeLine {
+    FontColor #000099
+    BackgroundColor SEQUENCE_LINE_COLOR
+    BorderColor SEQUENCE_LINE_COLOR
+  }
+
+  Reference {
+    FontColor #444444
+    HeaderFontColor #444444
+    BackgroundColor #FFFFFF
+    HeaderBackgroundColor #F0F0F0
+    BorderColor #c0c0c0
+    BorderThickness 1
+  }
+
+  Message {
+    Alignment left
+  }
+
+  Newpage {
+    SeparatorColor #666666
+  }
+
+  Arrow {
+    Thickness 2
+  }
+}


### PR DESCRIPTION
Sequence Diagram Kitchensink with applied skin:
![image](https://user-images.githubusercontent.com/425403/89126825-4ae4b000-d52c-11ea-8403-9bcbc2f3b0c0.png)

This is an initial effort at providing better styling - further enhancements (e.g. color-coding different stereotypes) might be added in the future.